### PR TITLE
add replace option in `net install package`

### DIFF
--- a/github.ado
+++ b/github.ado
@@ -581,7 +581,7 @@ prog define github
 		}
 		else {
 			net install `package', ///
-			from("https://raw.githubusercontent.com/`anything'/master/`path'")
+			from("https://raw.githubusercontent.com/`anything'/master/`path'") `replace'
 		}
 		
 		// check the version of the installing package

--- a/github.ado
+++ b/github.ado
@@ -520,7 +520,8 @@ prog define github
 		
 		quietly copy "`path'" "`packagename'-`version'.zip", replace
 		quietly unzipfile "`packagename'-`version'.zip", replace
-		local dir "`packagename'-`version'"
+		local ver2: subinstr local version "v" ""
+		local dir "`packagename'-`ver2'"
 		local wd : pwd
 		qui cd "`dir'" 
 		local pkg : pwd


### PR DESCRIPTION
Dear @haghish , 

I just added option `replace` when downloading from github repo and package has been downloaded previously from SSC. Now, if the user has the version in SSC and wants to download the version in Github, she can do it by just adding the option `replace`. 

Best, 