### PR TITLE
Fix install problem

### DIFF
--- a/github.pkg
+++ b/github.pkg
@@ -8,6 +8,7 @@ d License: MIT
 d 
 F abspath.ado
 F abspath.sthlp
+F gitget.ado
 F gitget.dta
 F gitget.sthlp
 F gitgetlist.ado
@@ -34,6 +35,6 @@ F make.ado
 F make.dlg
 F make.sthlp
 F makedlg.ado
-F wdpermissions.ado gitget.ado
+F wdpermissions.ado
 f gitget.dta
 f githubfiles.dta


### PR DESCRIPTION
ee1a8a36 created this line in `github.pkg`

https://github.com/haghish/github/blob/ee1a8a3687f35b127465bc643ab6f56704d814e2/github.pkg#L37

Having two files on one line causes the following error in Stata during install

```

. net install github, from("https://haghish.github.io/github/")
checking github consistency and verifying not already installed...
server refused to send file
could not copy https://haghish.github.io/github/wdpermissions.ado gitget.ado
(no action taken)
r(672);
```

The files should be separate