### PR TITLE
Fix yesterday's typo and create .gitattributes with some additional Linguist settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# settings for Linguist - which calcuates the repo language statistics on GitHub
+*.toc linguist-language=Stata
+*.pkg linguist-language=Stata
+*.log linguist-language=Stata
+*.smcl linguist-language=Stata

--- a/make.do
+++ b/make.do
@@ -12,7 +12,7 @@ make github, replace toc pkg  version(2.3.0)                             ///
      title("github package manager")                                     ///
      description("search, install, and manage github packages")          ///
      install("abspath.ado;abspath.sthlp;githubfindall.ado;"              ///
-     "githubfindall.sthlp;wdpermissions.ado"                             /// 
+     "githubfindall.sthlp;wdpermissions.ado;"                             /// 
 		 "gitget.ado;gitget.dta;gitget.sthlp;gitgetlist.ado;github.ado;"     ///
 		 "github.dlg;github.sthlp;githubcheck.ado;githubconfirm.ado;"        ///
 		 "githubdb.ado;githubdependency.ado;githubfiles.dta;"                ///


### PR DESCRIPTION
The settings in the `.gitattributes` file control the languages reported by the Languages pane of the repo.

Currently Linguist assigns `.do`, `.ado`, `.doh`, `.ihlp`, `.mata`, `.matah`, and `.sthlp` to Stata, which I get from here

https://github.com/github/linguist/blob/971e152fabca12e0ad386833eecb7b15e312a09f/lib/linguist/languages.yml#L5825-L5838

so these settings just assign some additional file extensions to Stata.