### PR TITLE
Allow usage when not installed in PLUS

### DIFF
--- a/github.ado
+++ b/github.ado
@@ -62,9 +62,6 @@ searching for a keyword. The table shows the options accordingly:
 | stable   | installs the latest stable release. otherwise the main branch is installed |
 | verson(_str_) | specifies a particular stable version (release tags) for the installation |
 
-By default the local package database is stored in the PLUS directory. This can be changed
-by setting the global GITHUB_DB_SYSDIR_CODEWORD to one of the sysdir codewords (see -help sysdir-).
-
 
 ### __github search__ options:
 

--- a/github.ado
+++ b/github.ado
@@ -62,6 +62,9 @@ searching for a keyword. The table shows the options accordingly:
 | stable   | installs the latest stable release. otherwise the main branch is installed |
 | verson(_str_) | specifies a particular stable version (release tags) for the installation |
 
+By default the local package database is stored in the PLUS directory. This can be changed
+by setting the global GITHUB_DB_SYSDIR_CODEWORD to one of the sysdir codewords (see -help sysdir-).
+
 
 ### __github search__ options:
 
@@ -182,7 +185,7 @@ prog define github
 	/// the options below are not documented yet                                  ///
 	force created(str) pushed(str) debug reference(str)			                      ///
 	duration(numlist max=1) perpage(numlist max=1)                                ///
-	append replace Number(numlist max=1) local path(str) sysdir_codeword(string)] 
+	append replace Number(numlist max=1) local path(str)] 
 	
 	
 	// correct the language
@@ -206,10 +209,10 @@ prog define github
 	// ---------
 	if "`1'" == "version" {
 	  if missing("`require'") {
-		  githubdb version, name(`anything') sysdir_codeword(`sysdir_codeword')
+		  githubdb version, name(`anything')
 		}
 		else {
-		  qui githubdb version, name(`anything') sysdir_codeword(`sysdir_codeword')
+		  qui githubdb version, name(`anything')
 			local currentversion `r(version)'
 			if "`r(version)'" != "`require'" {
 			  tokenize "`r(version)'", parse(".")
@@ -261,7 +264,7 @@ prog define github
 		if !missing("`3'") {
 			err 198
 		}
-		githubdb list, name("`2'") sysdir_codeword(`sysdir_codeword')
+		githubdb list, name("`2'")
 		exit
 	}
 	
@@ -276,21 +279,21 @@ prog define github
 		}
 		
 		// Make github command to update a package, if the username is also specified 
-		capture githubdb check, name("`anything'") sysdir_codeword(`sysdir_codeword')
+		capture githubdb check, name("`anything'")
 		if !missing("`r(address)'") {
 			github install `r(address)'
 		}
 		else {
 			tokenize "`anything'", parse("/")
 			if !missing("`3'") {
-				capture githubdb check, name("`anything'") sysdir_codeword(`sysdir_codeword')
+				capture githubdb check, name("`anything'")
 				if !missing("`r(address)'") {
 					github install `r(address)'
 				}
 			}
 			//otherwise display the original error
 			else {
-				githubdb check, name("`anything'") sysdir_codeword(`sysdir_codeword')
+				githubdb check, name("`anything'")
 			}
 		}
 		exit
@@ -304,7 +307,7 @@ prog define github
 		  di as err "package name is required"
 		  qui err 198
 		}
-		githubdb erase, name("`2'") sysdir_codeword(`sysdir_codeword')
+		githubdb erase, name("`2'")
 		ado uninstall `2'
 		exit
 	}
@@ -550,7 +553,7 @@ prog define github
 		// register the package in the database
 		githubdb add, address("`anything'") username("`username'") 			          	///
 		              reponame("`reponame'") name("`package'") force("`force'")     ///
-									version("`version'") sysdir_codeword(`sysdir_codeword')
+									version("`version'")
 									
 		di _n "{title:Checking package dependencies}" 
 		capture quietly findfile "dependency.do", path("`pkg'")
@@ -575,7 +578,7 @@ prog define github
 		}
 		
 		// make sure it is first uninstalled 
-		githubdb erase, name("`package'") sysdir_codeword(`sysdir_codeword')
+		githubdb erase, name("`package'")
 		capture quietly ado uninstall "`package'"
 		
 		if missing("`package'") {
@@ -595,7 +598,7 @@ prog define github
 		
 		githubdb add, address("`anything'") username("`username'") 			          	///
 		              reponame("`reponame'") name("`package'") force("`force'")     ///
-									version("`version'") sysdir_codeword(`sysdir_codeword')
+									version("`version'")
 		
 		di _n "{title:Checking package dependencies}" 
 		tempfile dep

--- a/github.ado
+++ b/github.ado
@@ -182,7 +182,7 @@ prog define github
 	/// the options below are not documented yet                                  ///
 	force created(str) pushed(str) debug reference(str)			                      ///
 	duration(numlist max=1) perpage(numlist max=1)                                ///
-	append replace Number(numlist max=1) local path(str)] 
+	append replace Number(numlist max=1) local path(str) sysdir_codeword(string)] 
 	
 	
 	// correct the language
@@ -206,10 +206,10 @@ prog define github
 	// ---------
 	if "`1'" == "version" {
 	  if missing("`require'") {
-		  githubdb version, name(`anything')
+		  githubdb version, name(`anything') sysdir_codeword(`sysdir_codeword')
 		}
 		else {
-		  qui githubdb version, name(`anything')
+		  qui githubdb version, name(`anything') sysdir_codeword(`sysdir_codeword')
 			local currentversion `r(version)'
 			if "`r(version)'" != "`require'" {
 			  tokenize "`r(version)'", parse(".")
@@ -261,7 +261,7 @@ prog define github
 		if !missing("`3'") {
 			err 198
 		}
-		githubdb list, name("`2'")
+		githubdb list, name("`2'") sysdir_codeword(`sysdir_codeword')
 		exit
 	}
 	
@@ -276,21 +276,21 @@ prog define github
 		}
 		
 		// Make github command to update a package, if the username is also specified 
-		capture githubdb check, name("`anything'")
+		capture githubdb check, name("`anything'") sysdir_codeword(`sysdir_codeword')
 		if !missing("`r(address)'") {
 			github install `r(address)'
 		}
 		else {
 			tokenize "`anything'", parse("/")
 			if !missing("`3'") {
-				capture githubdb check, name("`anything'")
+				capture githubdb check, name("`anything'") sysdir_codeword(`sysdir_codeword')
 				if !missing("`r(address)'") {
 					github install `r(address)'
 				}
 			}
 			//otherwise display the original error
 			else {
-				githubdb check, name("`anything'")
+				githubdb check, name("`anything'") sysdir_codeword(`sysdir_codeword')
 			}
 		}
 		exit
@@ -304,7 +304,7 @@ prog define github
 		  di as err "package name is required"
 		  qui err 198
 		}
-		githubdb erase, name("`2'")
+		githubdb erase, name("`2'") sysdir_codeword(`sysdir_codeword')
 		ado uninstall `2'
 		exit
 	}
@@ -550,7 +550,7 @@ prog define github
 		// register the package in the database
 		githubdb add, address("`anything'") username("`username'") 			          	///
 		              reponame("`reponame'") name("`package'") force("`force'")     ///
-									version("`version'")
+									version("`version'") sysdir_codeword(`sysdir_codeword')
 									
 		di _n "{title:Checking package dependencies}" 
 		capture quietly findfile "dependency.do", path("`pkg'")
@@ -575,7 +575,7 @@ prog define github
 		}
 		
 		// make sure it is first uninstalled 
-		githubdb erase, name("`package'")
+		githubdb erase, name("`package'") sysdir_codeword(`sysdir_codeword')
 		capture quietly ado uninstall "`package'"
 		
 		if missing("`package'") {
@@ -595,7 +595,7 @@ prog define github
 		
 		githubdb add, address("`anything'") username("`username'") 			          	///
 		              reponame("`reponame'") name("`package'") force("`force'")     ///
-									version("`version'")
+									version("`version'") sysdir_codeword(`sysdir_codeword')
 		
 		di _n "{title:Checking package dependencies}" 
 		tempfile dep

--- a/githubdb.ado
+++ b/githubdb.ado
@@ -2,10 +2,10 @@
 
 *cap prog drop githubdb
 program githubdb, rclass
-	syntax anything, [address(str) username(str) reponame(str) name(str) force(str) version(str) sysdir_codeword(string)]
+	syntax anything, [address(str) username(str) reponame(str) name(str) force(str) version(str)]
 	
-	if "`sysdir_codeword'"=="" loc sysdir_codeword "PLUS"
-	loc sysdir_codeword = strlower("`sysdir_codeword'")
+	loc sysdir_codeword = strlower("${GITHUB_DB_SYSDIR_CODEWORD}")
+	if "`sysdir_codeword'"=="" loc sysdir_codeword "plus"
 	_assert inlist("`sysdir_codeword'","stata", "base", "site", "plus", "personal", "oldplace"), msg("githubdb: sysdir_codeword not valid, see -help sysdir-")
 	
 	// test the database, if it doesn't exist create it!

--- a/githubdb.ado
+++ b/githubdb.ado
@@ -2,10 +2,14 @@
 
 *cap prog drop githubdb
 program githubdb, rclass
-	syntax anything, [address(str) username(str) reponame(str) name(str) force(str) version(str)]
+	syntax anything, [address(str) username(str) reponame(str) name(str) force(str) version(str) sysdir_codeword(string)]
+	
+	if "`sysdir_codeword'"=="" loc sysdir_codeword "PLUS"
+	loc sysdir_codeword = strlower("`sysdir_codeword'")
+	_assert inlist("`sysdir_codeword'","stata", "base", "site", "plus", "personal", "oldplace"), msg("githubdb: sysdir_codeword not valid, see -help sysdir-")
 	
 	// test the database, if it doesn't exist create it!
-	capture findfile github.dta, path("`c(sysdir_plus)'g/")
+	capture findfile github.dta, path("`c(sysdir_`sysdir_codeword')'g/")
 	if _rc {
 		preserve
 		quietly clear
@@ -17,13 +21,13 @@ program githubdb, rclass
 		qui generate str name = ""
 		qui generate str version = ""
 		qui generate str force = ""
-		qui save "`c(sysdir_plus)'g/github.dta", replace
+		qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
 		restore
 	}
 	
 	// for versions betwen 1.4.0 to 1.4.5 make sure the data set has these variables:
 	// -----------------------------------------------------------------------
-	capture findfile github.dta, path("`c(sysdir_plus)'g/")
+	capture findfile github.dta, path("`c(sysdir_`sysdir_codeword')'g/")
 	if _rc == 0 {
 		preserve
 		use "`r(fn)'", clear
@@ -31,13 +35,13 @@ program githubdb, rclass
 		if _rc qui generate str version = ""
 		cap confirm variable force
 		if _rc qui generate str force   = ""
-		qui save "`c(sysdir_plus)'g/github.dta", replace
+		qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
 		restore
 	}
 	
 	// processing the subcommands
 	// =========================================================================
-	capture findfile github.dta, path("`c(sysdir_plus)'g/")
+	capture findfile github.dta, path("`c(sysdir_`sysdir_codeword')'g/")
 	if _rc == 0 {
 		
 		// check 
@@ -106,7 +110,7 @@ program githubdb, rclass
 			qui replace name = "`name'"         in `nextN'
 			qui replace version = "`version'"   in `nextN'
 			qui replace force = "`force'"       in `nextN'
-			qui save "`c(sysdir_plus)'g/github.dta", replace
+			qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
 			restore
 		}
 		
@@ -117,7 +121,7 @@ program githubdb, rclass
 			use "`r(fn)'", clear
 			if missing("`name'") err 198
 			quietly drop if name == "`name'"  // clean the database
-			qui save "`c(sysdir_plus)'g/github.dta", replace
+			qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
 			restore
 		}
 		
@@ -153,7 +157,7 @@ program githubdb, rclass
 			forval num = 1/`length' {	
 				if strpos(`"`pkglist'"', name[`num']) < 1 {
 					qui drop in `num'
-					qui save "`c(sysdir_plus)'g/github.dta", replace
+					qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
 				}
 			}
 

--- a/githubdb.ado
+++ b/githubdb.ado
@@ -4,12 +4,12 @@
 program githubdb, rclass
 	syntax anything, [address(str) username(str) reponame(str) name(str) force(str) version(str)]
 	
-	loc sysdir_codeword = strlower("${GITHUB_DB_SYSDIR_CODEWORD}")
-	if "`sysdir_codeword'"=="" loc sysdir_codeword "plus"
-	_assert inlist("`sysdir_codeword'","stata", "base", "site", "plus", "personal", "oldplace"), msg("githubdb: sysdir_codeword not valid, see -help sysdir-")
+	//Determine where the db should be
+	qui findfile github.ado
+	loc sysdir_base = substr("`r(fn)'", 1, strlen("`r(fn)'")-12)
 	
 	// test the database, if it doesn't exist create it!
-	capture findfile github.dta, path("`c(sysdir_`sysdir_codeword')'g/")
+	capture findfile github.dta, path("`sysdir_base'g/")
 	if _rc {
 		preserve
 		quietly clear
@@ -21,13 +21,13 @@ program githubdb, rclass
 		qui generate str name = ""
 		qui generate str version = ""
 		qui generate str force = ""
-		qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
+		qui save "`sysdir_base'g/github.dta", replace
 		restore
 	}
 	
 	// for versions betwen 1.4.0 to 1.4.5 make sure the data set has these variables:
 	// -----------------------------------------------------------------------
-	capture findfile github.dta, path("`c(sysdir_`sysdir_codeword')'g/")
+	capture findfile github.dta, path("`sysdir_base'g/")
 	if _rc == 0 {
 		preserve
 		use "`r(fn)'", clear
@@ -35,13 +35,13 @@ program githubdb, rclass
 		if _rc qui generate str version = ""
 		cap confirm variable force
 		if _rc qui generate str force   = ""
-		qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
+		qui save "`sysdir_base'g/github.dta", replace
 		restore
 	}
 	
 	// processing the subcommands
 	// =========================================================================
-	capture findfile github.dta, path("`c(sysdir_`sysdir_codeword')'g/")
+	capture findfile github.dta, path("`sysdir_base'g/")
 	if _rc == 0 {
 		
 		// check 
@@ -110,7 +110,7 @@ program githubdb, rclass
 			qui replace name = "`name'"         in `nextN'
 			qui replace version = "`version'"   in `nextN'
 			qui replace force = "`force'"       in `nextN'
-			qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
+			qui save "`sysdir_base'g/github.dta", replace
 			restore
 		}
 		
@@ -121,7 +121,7 @@ program githubdb, rclass
 			use "`r(fn)'", clear
 			if missing("`name'") err 198
 			quietly drop if name == "`name'"  // clean the database
-			qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
+			qui save "`sysdir_base'g/github.dta", replace
 			restore
 		}
 		
@@ -157,7 +157,7 @@ program githubdb, rclass
 			forval num = 1/`length' {	
 				if strpos(`"`pkglist'"', name[`num']) < 1 {
 					qui drop in `num'
-					qui save "`c(sysdir_`sysdir_codeword')'g/github.dta", replace
+					qui save "`sysdir_base'g/github.dta", replace
 				}
 			}
 


### PR DESCRIPTION
This patch makes `github` look for the `github.dta` in the same sysdir as it's installed into, rather than only looking in `PLUS`. This allows the program to work when it's installed into PERSONAL, for example.