### PR TITLE
Fix package name/repo name mismatch errors

### DIFF
--- a/github.ado
+++ b/github.ado
@@ -523,7 +523,7 @@ prog define github
 		
 		quietly copy "`path'" "`packagename'-`version'.zip", replace
 		quietly unzipfile "`packagename'-`version'.zip", replace
-		local dir "`packagename'-`version'"
+		local dir "`reponame'-`version'"
 		local wd : pwd
 		qui cd "`dir'" 
 		local pkg : pwd


### PR DESCRIPTION
## The issue
The `github install` command was failing to download stable/release versions of packages where the package name and repository name were not the same.

### Specifics
The command would download a zipped folder, which contains the repository source code in a folder named after the repository and suffixed with the version number in use. For example, the command
```stata
github install my_account/my_repo, package(my_pkg) version(X.Y.Z) 
```
would download a zipped folder called `my_pkg-X.Y.Z.zip`, within which you'd find a folder named `my_repo-X.Y.Z`. The command would unzip `my_pkg-X.Y.Z.zip` correctly, but would then try to move the working directory to `my_pkg-X.Y.Z` instead of `my_repo-X.Y.Z`. This would fail, causing the installation process to terminate.

## The fix
To fix this, I changed the command to move working directory to `my_repo-X.Y.Z`, which didn't break installation of any packages I tried it with. It did, however, let me install specific versions of packages where the repo/package names are different.